### PR TITLE
Remove unused dependency angular-cli

### DIFF
--- a/bridgechain.sh
+++ b/bridgechain.sh
@@ -14,7 +14,7 @@ readonly __root="$(cd "$(dirname "${__dir}")" && pwd)"
 readonly __manifest="${__dir}/manifest.json"
 
 readonly -a DEPENDENCIES_PROGRAMS=('postgresql postgresql-contrib libpq-dev build-essential python git curl jq libtool autoconf locales automake locate zip unzip htop nmon iftop pkg-config libcairo2-dev libgif-dev')
-readonly -a DEPENDENCIES_NODEJS=('forever grunt-cli node-sass angular-cli')
+readonly -a DEPENDENCIES_NODEJS=('forever grunt-cli node-sass')
 
 source "${__dir}/bootstrap/lib.sh"
 source "${__dir}/bootstrap/app.sh"


### PR DESCRIPTION
I performed installation of a node and an explorer without angular-cli. Both applications are started and I can send vote transactions from my Ark wallet. All this was done without the angular-cli installation.

If I am not missing something, this dependency is obsolete.

Closes #27 